### PR TITLE
fix instruct error

### DIFF
--- a/src/instruct.jl
+++ b/src/instruct.jl
@@ -12,6 +12,17 @@ const Locations{T} = NTuple{N, T} where N
 const BitConfigs{T} = NTuple{N, T} where N
 
 function YaoBase.instruct!(
+    state::AbstractVecOrMat{T1},
+    operator::AbstractMatrix{T2},
+    locs::NTuple{M, Int},
+    control_locs::NTuple{C, Int}=(),
+    control_bits::NTuple{C, Int}=()) where {T1, T2, M, C}
+    
+    @warn "Element Type Mismatch: register $(T1), operator $(T2). Converting operator to match, this may cause performance issue"
+    return instruct!(state, copyto!(similar(operator, T1), operator), locs, control_locs, control_bits)
+end
+
+function YaoBase.instruct!(
     state::AbstractVecOrMat{T},
     operator::AbstractMatrix{T},
     locs::NTuple{M, Int},

--- a/src/register.jl
+++ b/src/register.jl
@@ -73,8 +73,8 @@ function ArrayReg{B}(raw::MT) where {B, T, MT <: AbstractMatrix{T}}
     return ArrayReg{B, T, MT}(raw)
 end
 
-function _warn_type(raw)
-    eltype(raw) <: Complex || @warn "Input type of `ArrayReg` is not Complex, got $(eltype(raw))"
+function _warn_type(raw::AbstractArray{T}) where T
+    T <: Complex || @warn "Input type of `ArrayReg` is not Complex, got $(eltype(raw))"
 end
 
 ArrayReg(raw::AbstractVector) = (_warn_type(raw); ArrayReg(reshape(raw, :, 1)))

--- a/test/instruct.jl
+++ b/test/instruct.jl
@@ -30,6 +30,11 @@ using YaoBase.Const
     @test instruct!(copy(ST), I2, (1, )) ≈ ST
 end
 
+@testset "test auto conversion" begin
+    v = rand(ComplexF32, 1<<8)
+    @test_logs (:warn,"Element Type Mismatch: register Complex{Float32}, operator Complex{Float64}. Converting operator to match, this may cause performance issue") instruct!(v, Const.Pd, (1, ))
+end
+
 
 @testset "test general control unitary operator" begin
     ST = randn(ComplexF64, 1<<5)


### PR DESCRIPTION
This fix the following error

```julia
instruct!(rand(ComplexF32, 1<<8), Const.Pd, (1, ))
```

This is because if the state's element type does not match the operator's, a copy will happen, and we should try to avoid this, but it is not convenient to make it error either.