### PR TITLE
Fix instruction disentangle

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ YaoBase = "a8f54c17-34bc-5a9d-b050-f522fe3f755f"
 [compat]
 BitBasis = "^0.5.0"
 LuxurySparse = "~0.4.0"
-YaoBase = "~0.9.0"
+YaoBase = "~0.10.0"
 julia = "^1.0.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -6,16 +6,17 @@ version = "0.3.9"
 BitBasis = "50ba71b6-fa0f-514d-ae9a-0916efc90dcf"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LuxurySparse = "d05aeea4-b7d4-55ac-b691-9e7fabb07ba2"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 YaoBase = "a8f54c17-34bc-5a9d-b050-f522fe3f755f"
 
 [compat]
-julia = "^1.0.0"
+BitBasis = "^0.5.0"
 LuxurySparse = "~0.4.0"
 YaoBase = "~0.9.0"
-BitBasis = "^0.5.0"
+julia = "^1.0.0"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/instruct.jl
+++ b/src/instruct.jl
@@ -249,28 +249,16 @@ end
 
 # Specialized
 import YaoBase: rot_mat
-"""rotation gate, will be removed to YaoBase."""
-function rot_mat(::Type{T}, gen::AbstractMatrix, theta::Real) where {N, T}
-    I = IMatrix{size(gen, 1), T}()
-    m = I * cos(theta / 2) - im * sin(theta / 2) * gen
-    if eltype(m) != T
-        m2 = similar(m, T)
-        copyto!(m2, m)
-        return m2
-    else
-        return m
-    end
-end
 
-YaoBase.rot_mat(::Type{T}, ::Val{:Rx}, theta::Real) where T =
+rot_mat(::Type{T}, ::Val{:Rx}, theta::Real) where T =
     T[cos(theta/2) -im * sin(theta/2); -im * sin(theta/2) cos(theta/2)]
-YaoBase.rot_mat(::Type{T}, ::Val{:Ry}, theta::Real) where T =
+rot_mat(::Type{T}, ::Val{:Ry}, theta::Real) where T =
     T[cos(theta/2) -sin(theta/2); sin(theta/2) cos(theta/2)]
-YaoBase.rot_mat(::Type{T}, ::Val{:Rz}, theta::Real) where T =
+rot_mat(::Type{T}, ::Val{:Rz}, theta::Real) where T =
     Diagonal(T[exp(-im*theta/2), exp(im*theta/2)])
-YaoBase.rot_mat(::Type{T}, ::Val{:CPHASE}, theta::Real) where T =
+rot_mat(::Type{T}, ::Val{:CPHASE}, theta::Real) where T =
     Diagonal(T[1, 1, 1, exp(im*theta)])
-YaoBase.rot_mat(::Type{T}, ::Val{:PSWAP}, theta::Real) where T =
+rot_mat(::Type{T}, ::Val{:PSWAP}, theta::Real) where T =
     rot_mat(T, Const.SWAP, theta)
 
 for G in [:Rx, :Ry, :Rz, :CPHASE]

--- a/src/instruct.jl
+++ b/src/instruct.jl
@@ -248,6 +248,19 @@ end
 
 
 # Specialized
+"""rotation gate, will be removed to YaoBase."""
+function rot_mat(::Type{T}, gen::AbstractMatrix, theta::Real) where {N, T}
+    I = IMatrix{size(gen, 1), T}()
+    m = I * cos(theta / 2) - im * sin(theta / 2) * gen
+    if eltype(m) != T
+        m2 = similar(m, T)
+        copyto!(m2, m)
+        return m2
+    else
+        return m
+    end
+end
+
 YaoBase.rot_mat(::Type{T}, ::Val{:Rx}, theta::Real) where T =
     T[cos(theta/2) -im * sin(theta/2); -im * sin(theta/2) cos(theta/2)]
 YaoBase.rot_mat(::Type{T}, ::Val{:Ry}, theta::Real) where T =

--- a/src/instruct.jl
+++ b/src/instruct.jl
@@ -6,6 +6,10 @@
 using YaoBase, BitBasis, LuxurySparse, StaticArrays
 export instruct!
 
+function YaoBase.instruct!(reg::ArrayReg, operator, args...; kwargs...)
+    instruct!(state(reg), operator, args...; kwargs...)
+end
+
 """
     SPECIALIZATION_LIST::Vector{Symbol}
 

--- a/src/instruct.jl
+++ b/src/instruct.jl
@@ -248,6 +248,7 @@ end
 
 
 # Specialized
+import YaoBase: rot_mat
 """rotation gate, will be removed to YaoBase."""
 function rot_mat(::Type{T}, gen::AbstractMatrix, theta::Real) where {N, T}
     I = IMatrix{size(gen, 1), T}()

--- a/src/instruct.jl
+++ b/src/instruct.jl
@@ -7,7 +7,7 @@ using YaoBase, BitBasis, LuxurySparse, StaticArrays
 export instruct!
 
 function YaoBase.instruct!(reg::ArrayReg, operator, args...; kwargs...)
-    instruct!(state(reg), operator, args...; kwargs...)
+    instruct!(matvec(reg.state), operator, args...; kwargs...)
 end
 
 """

--- a/src/instruct.jl
+++ b/src/instruct.jl
@@ -246,6 +246,36 @@ for G in [:X, :Y, :Z, :S, :T, :Sdag, :Tdag]
                 instruct!(state, g, (locs, ), control_locs, control_bits)
 end
 
+
+# Specialized
+YaoBase.rot_mat(::Type{T}, ::Val{:Rx}, theta::Real) where T =
+    T[cos(theta/2) -im * sin(theta/2); -im * sin(theta/2) cos(theta/2)]
+YaoBase.rot_mat(::Type{T}, ::Val{:Ry}, theta::Real) where T =
+    T[cos(theta/2) -sin(theta/2); sin(theta/2) cos(theta/2)]
+YaoBase.rot_mat(::Type{T}, ::Val{:Rz}, theta::Real) where T =
+    Diagonal(T[exp(-im*theta/2), exp(im*theta/2)])
+YaoBase.rot_mat(::Type{T}, ::Val{:CPHASE}, theta::Real) where T =
+    Diagonal(T[1, 1, 1, exp(im*theta)])
+YaoBase.rot_mat(::Type{T}, ::Val{:PSWAP}, theta::Real) where T =
+    rot_mat(T, Const.SWAP, theta)
+
+for G in [:Rx, :Ry, :Rz, :CPHASE]
+    # forward single gates
+    @eval function YaoBase.instruct!(state::AbstractVecOrMat{T}, g::Val{$(QuoteNode(G))},
+                            locs::Union{Int, NTuple{N3,Int}},
+                            control_locs::NTuple{N1, Int},
+                            control_bits::NTuple{N2, Int}, theta::Real) where {T, N1, N2, N3}
+        m = rot_mat(T, g, theta)
+        instruct!(state, m, locs, control_locs, control_bits)
+    end
+end
+
+# forward single gates
+@eval function YaoBase.instruct!(state::AbstractVecOrMat{T}, g::Val,
+                        locs::Union{Int, NTuple{N1, Int}}, theta::Real) where {T, N1}
+    instruct!(state, g, locs, (), (), theta)
+end
+
 function YaoBase.instruct!(
     state::AbstractVecOrMat{T}, ::Val{:X},
     locs::NTuple{N1, Int},
@@ -415,6 +445,34 @@ function YaoBase.instruct!(
     c = T(-im * sin(theta/2))
     e = T(exp(-im/2*theta))
     for b in basis(state)
+        if b&mask1==0
+            i = b+1
+            i_ = b ⊻ mask12 + 1
+            if b&mask2==mask2
+                u1rows!(state, i, i_, a, c, c, a)
+            else
+                mulrow!(state, i, e)
+                mulrow!(state, i_, e)
+            end
+        end
+    end
+    return state
+end
+
+function YaoBase.instruct!(
+        state::AbstractVecOrMat{T},
+        ::Val{:PSWAP},
+        locs::Tuple{Int, Int},
+        control_locs::NTuple{C, Int},
+        control_bits::NTuple{C, Int},
+        theta::Real) where {T, C}
+    mask1 = bmask(locs[1])
+    mask2 = bmask(locs[2])
+    mask12 = mask1|mask2
+    a = T(cos(theta/2))
+    c = T(-im * sin(theta/2))
+    e = T(exp(-im/2*theta))
+    for b in itercontrol(log2i(size(state, 1)), [control_locs...], [control_bits...])
         if b&mask1==0
             i = b+1
             i_ = b ⊻ mask12 + 1

--- a/src/measure.jl
+++ b/src/measure.jl
@@ -1,4 +1,4 @@
-using StatsBase, StaticArrays, BitBasis
+using StatsBase, StaticArrays, BitBasis, Random
 export measure,
     measure!,
     measure_remove!,
@@ -6,30 +6,30 @@ export measure,
     select,
     select!
 
-_measure(pl::AbstractVector, nshots::Int) = sample(0:length(pl)-1, Weights(pl), nshots)
-function _measure(pl::AbstractMatrix, nshots::Int)
+_measure(rng::AbstractRNG, pl::AbstractVector, nshots::Int) = sample(rng, 0:length(pl)-1, Weights(pl), nshots)
+function _measure(rng::AbstractRNG, pl::AbstractMatrix, nshots::Int)
     B = size(pl, 2)
     res = Matrix{Int}(undef, nshots, B)
     for ib=1:B
-        @inbounds res[:,ib] = _measure(view(pl,:,ib), nshots)
+        @inbounds res[:,ib] = _measure(rng, view(pl,:,ib), nshots)
     end
     return res
 end
 
-YaoBase.measure(::ComputationalBasis, reg::ArrayReg{1}, ::AllLocs; nshots::Int=1) = _measure(reg |> probs, nshots)
+YaoBase.measure(rng::AbstractRNG, ::ComputationalBasis, reg::ArrayReg{1}, ::AllLocs; nshots::Int=1) = _measure(rng, reg |> probs, nshots)
 
-function YaoBase.measure(::ComputationalBasis, reg::ArrayReg{B}, ::AllLocs; nshots::Int=1) where B
+function YaoBase.measure(rng::AbstractRNG, ::ComputationalBasis, reg::ArrayReg{B}, ::AllLocs; nshots::Int=1) where B
     pl = dropdims(sum(reg |> rank3 .|> abs2, dims=2), dims=2)
-    return _measure(pl, nshots)
+    return _measure(rng, pl, nshots)
 end
 
-function YaoBase.measure_remove!(::ComputationalBasis, reg::ArrayReg{B}, ::AllLocs) where B
+function YaoBase.measure_remove!(rng::AbstractRNG, ::ComputationalBasis, reg::ArrayReg{B}, ::AllLocs) where B
     state = reg |> rank3
     nstate = similar(reg.state, 1<<nremain(reg), B)
     pl = dropdims(sum(state .|> abs2, dims=2), dims=2)
     res = Vector{Int}(undef, B)
     @inbounds for ib = 1:B
-        ires = _measure(view(pl, :, ib), 1)[]
+        ires = _measure(rng, view(pl, :, ib), 1)[]
         nstate[:,ib] = view(state, ires+1,:,ib)./sqrt(pl[ires+1, ib])
         res[ib] = ires
     end
@@ -37,10 +37,10 @@ function YaoBase.measure_remove!(::ComputationalBasis, reg::ArrayReg{B}, ::AllLo
     return res
 end
 
-function YaoBase.measure!(::ComputationalBasis, reg::ArrayReg{B}, ::AllLocs) where B
+function YaoBase.measure!(rng::AbstractRNG, ::ComputationalBasis, reg::ArrayReg{B}, ::AllLocs) where B
     state = reg |> rank3
     nstate = zero(state)
-    res = measure_remove!(reg)
+    res = measure_remove!(rng, reg)
     _nstate = reshape(reg.state, :, B)
     for ib in 1:B
         @inbounds nstate[res[ib]+1, :, ib] .= view(_nstate, :,ib)
@@ -49,11 +49,11 @@ function YaoBase.measure!(::ComputationalBasis, reg::ArrayReg{B}, ::AllLocs) whe
     return res
 end
 
-function YaoBase.measure_collapseto!(::ComputationalBasis, reg::ArrayReg{B}, ::AllLocs; config::Integer=0) where B
+function YaoBase.measure_collapseto!(rng::AbstractRNG, ::ComputationalBasis, reg::ArrayReg{B}, ::AllLocs; config::Integer=0) where B
     state = rank3(reg)
     M, N, B1 = size(state)
     nstate = zero(state)
-    res = measure_remove!(reg)
+    res = measure_remove!(rng, reg)
     nstate[config+1, :, :] = reshape(reg.state, :, B)
     reg.state = reshape(nstate, M, N*B)
     return res

--- a/test/focus.jl
+++ b/test/focus.jl
@@ -62,5 +62,5 @@ end
 
 @testset "partial trace" begin
     r = join(ArrayReg(bit"111"), zero_state(1))
-    partial_tr(r, 1) ≈ ArrayReg(bit"111")
+    @test partial_tr(r, 1) ≈ ArrayReg(bit"111")
 end

--- a/test/instruct.jl
+++ b/test/instruct.jl
@@ -105,7 +105,7 @@ end
     for (R, G) in [(:Rx, X), (:Ry, Y), (:Rz, Z), (:PSWAP, SWAP)]
         @test rot_mat(T, Val(R), theta) ≈ rot_mat(T, G, theta)
     end
-    @test rot_mat(T, Val(:CPHASE), theta) ≈ rot_mat(T, CZ, theta)*exp(im*theta/2)
+    @test rot_mat(T, Val(:CPHASE), theta) ≈ rot_mat(T, Diagonal([1, 1, 1, -1]), theta)*exp(im*theta/2)
     for ST in [randn(ComplexF64, 1 << 5), randn(ComplexF64, 1 << 5, 10)]
         for R in [:Rx, :Ry, :Rz]
             @test instruct!(copy(ST), Val(R), (4,), θ) ≈ instruct!(copy(ST), Matrix(rot_mat(T, Val(R), θ)), (4,))

--- a/test/instruct.jl
+++ b/test/instruct.jl
@@ -6,6 +6,7 @@ using YaoBase.Const
 @testset "test general unitary instruction" begin
     U1 = randn(ComplexF64, 2, 2)
     ST = randn(ComplexF64, 1<<4)
+    REG = ArrayReg(ST)
     I2 = IMatrix(2)
     M = kron(I2, U1, I2, I2) * ST
 
@@ -18,6 +19,8 @@ using YaoBase.Const
 
     @test instruct!(copy(ST), kron(U1, U1), (3, 1)) ≈
         instruct!(instruct!(copy(ST), U1, 3), U1, 1)
+    @test instruct!(copy(REG), kron(U1, U1), (3, 1)) ≈
+        instruct!(instruct!(copy(REG), U1, 3), U1, 1)
 
     @test instruct!(reshape(copy(ST), :, 1), kron(U1, U1), (3, 1)) ≈
         instruct!(instruct!(reshape(copy(ST), :, 1), U1, 3), U1, 1)


### PR DESCRIPTION
* fix incorrect use of `AbstractRegister` and `ArrayReg`,
* new rotation gate instruction,
* forward instructions to registers,
* merge #21  to pass tests.

close #21 