### PR TITLE
fix partial bra * ket

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -74,7 +74,16 @@ for op in [:(==), :≈]
     end
 end
 
-Base.:*(bra::AdjointArrayReg{1}, ket::ArrayReg{1}) = dot(state(parent(bra)), state(ket))
+function Base.:*(bra::AdjointArrayReg{1}, ket::ArrayReg{1})
+    if nremain(bra) == nremain(ket) == 0 # all active
+        return dot(state(parent(bra)), state(ket))
+    elseif nremain(bra) == 0 # <s|active> |remain>
+        return ArrayReg{1}(state(bra) * state(ket))
+    else
+        error("partially contract ⟨bra|ket⟩ is not supported, expect ⟨bra| to be fully actived. nactive(bra)/nqubits(bra)=$(nactive(bra))/$(nqubits(bra))")
+    end
+end
+
 Base.:*(bra::AdjointArrayReg{B}, ket::ArrayReg{B}) where B = bra .* ket
 
 # broadcast

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -40,3 +40,18 @@ end
     @test reg1 * 2 == 2 * reg1
     @test reg1' * 2 == 2 * reg1'
 end
+
+@testset "partial ⟨bra|ket⟩" begin
+    bra = ArrayReg(bit"10")
+    ket = ArrayReg(bit"100") + 2ArrayReg(bit"110") + 3ArrayReg(bit"111")
+
+    focus!(ket, 2:3)
+    t = bra' * ket
+    relax!(t, 1)
+    @test state(t) ≈ [1, 0]
+
+    relax!(ket, 2:3)
+    focus!(ket, 1)
+    focus!(bra, 2)
+    @test_throws ErrorException bra' * ket
+end


### PR DESCRIPTION
previous implementation causes the following errors in YaoSym

```jl
bra"10" * focus!(ket"101", 1:2)
```

this fix the issue. now I can do assignment 2's first problem with YaoSym:

![image](https://user-images.githubusercontent.com/8445510/65556735-ab639380-defe-11e9-94b0-ba194845091c.png)
