### PR TITLE
propagate inbounds

### DIFF
--- a/src/instruct.jl
+++ b/src/instruct.jl
@@ -56,7 +56,7 @@ end
 
 function _instruct!(state::AbstractVecOrMat{T}, U::AbstractMatrix{T}, locs_raw::SVector, ic::IterControl) where T
     controldo(ic) do i
-        unrows!(state, locs_raw .+ i, U)
+        @inbounds unrows!(state, locs_raw .+ i, U)
     end
     return state
 end
@@ -64,7 +64,7 @@ end
 function _instruct!(state::AbstractVecOrMat{T}, U::SDSparseMatrixCSC{T}, locs_raw::SVector, ic::IterControl) where T
     work = ndims(state)==1 ? similar(state, length(locs_raw)) : similar(state, length(locs_raw), size(state,2))
     controldo(ic) do i
-        unrows!(state, locs_raw .+ i, U, work)
+        @inbounds unrows!(state, locs_raw .+ i, U, work)
     end
     return state
 end
@@ -146,7 +146,7 @@ function YaoBase.instruct!(state::AbstractVecOrMat{T}, ::Val{:Y}, locs::NTuple{N
     bit_parity = iseven(length(locs)) ? 1 : -1
     factor = T(-im)^length(locs)
 
-    for b in basis(Int, state)
+    @inbounds for b in basis(Int, state)
         if anyone(b, do_mask)
             i = b + 1
             i_ = flip(b, mask) + 1
@@ -160,7 +160,7 @@ end
 
 function YaoBase.instruct!(state::AbstractVecOrMat{T}, ::Val{:Z}, locs::NTuple{N, Int}) where {T, N}
     mask = bmask(Int, locs)
-    for b in basis(Int, state)
+    @inbounds for b in basis(Int, state)
         if isodd(count_ones(b & mask))
             mulrow!(state, b + 1, -1)
         end
@@ -171,7 +171,7 @@ end
 for (G, FACTOR) in zip([:S, :T, :Sdag, :Tdag], [:(im), :($(exp(im*π/4))), :(-im), :($(exp(-im*π/4)))])
     @eval function YaoBase.instruct!(state::AbstractVecOrMat{T}, ::Val{$(QuoteNode(G))}, locs::NTuple{N, Int}) where {T, N}
         mask = bmask(Int, locs)
-        for b in basis(Int, state)
+        @inbounds for b in basis(Int, state)
             mulrow!(state, b+1, $FACTOR^count_ones(b & mask))
         end
         return state
@@ -190,7 +190,7 @@ for (G, FACTOR) in zip([:Z, :S, :T, :Sdag, :Tdag], [:(-1), :(im), :($(exp(im*π/
         mask = bmask(locs)
         step = 1<<(locs-1)
         step_2 = 1<<locs
-        for j in 0:step_2:size(state, 1)-step
+        @inbounds for j in 0:step_2:size(state, 1)-step
             for i in j+step+1:j+step_2
                 mulrow!(state, i, $FACTOR)
             end
@@ -250,7 +250,7 @@ function YaoBase.instruct!(
 
     ctrl = controller((control_locs..., locs[1]), (control_bits..., 0))
     mask2 = bmask(locs)
-    for b in basis(state)
+    @inbounds for b in basis(state)
         if ctrl(b)
             i = b + 1
             i_ = flip(b, mask2) + 1
@@ -268,7 +268,7 @@ function YaoBase.instruct!(
 
     ctrl = controller((control_locs..., locs[1]), (control_bits..., 0))
     mask2 = bmask(locs)
-    for b in basis(state)
+    @inbounds for b in basis(state)
         local i_::Int
         if ctrl(b)
             i = b + 1
@@ -287,7 +287,7 @@ for (G, FACTOR) in zip([:Z, :S, :T, :Sdag, :Tdag], [:(-1), :(im), :($(exp(im*π/
             control_bits::NTuple{N3, Int}) where {T, N1, N2, N3}
 
         ctrl = controller([control_locs..., locs[1]], [control_bits..., 1])
-        for b in basis(state)
+        @inbounds for b in basis(state)
             if ctrl(b)
                 mulrow!(state, b+1, $FACTOR)
             end
@@ -369,7 +369,7 @@ for (G, FACTOR) in zip([:Z, :S, :T, :Sdag, :Tdag], [:(-1), :(im), :($(exp(im*π/
         step = 1 << (control_locs - 1)
         step_2 = 1 << control_locs
         start = control_bits == 1 ? step : 0
-        for j in start:step_2:size(state, 1)-step+start
+        @inbounds for j in start:step_2:size(state, 1)-step+start
             for i in j+1:j+step
                 if allone(i-1, mask2)
                     mulrow!(state, i, $FACTOR)
@@ -389,7 +389,7 @@ function YaoBase.instruct!(
     mask1 = bmask(locs[1])
     mask2 = bmask(locs[2])
     mask12 = mask1|mask2
-    for b in basis(state)
+    @inbounds for b in basis(state)
         if b&mask1==0 && b&mask2==mask2
             i = b+1
             i_ = b ⊻ mask12 + 1
@@ -410,7 +410,7 @@ function YaoBase.instruct!(
     a = T(cos(theta/2))
     c = T(-im * sin(theta/2))
     e = T(exp(-im/2*theta))
-    for b in basis(state)
+    @inbounds for b in basis(state)
         if b&mask1==0
             i = b+1
             i_ = b ⊻ mask12 + 1
@@ -438,7 +438,7 @@ function YaoBase.instruct!(
     a = T(cos(theta/2))
     c = T(-im * sin(theta/2))
     e = T(exp(-im/2*theta))
-    for b in itercontrol(log2i(size(state, 1)), [control_locs...], [control_bits...])
+    @inbounds for b in itercontrol(log2i(size(state, 1)), [control_locs...], [control_bits...])
         if b&mask1==0
             i = b+1
             i_ = b ⊻ mask12 + 1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,8 +28,8 @@ swap row i and row j of v inplace, with f1, f2 factors applied on i and j (befor
 """
 function swaprows! end
 
-@inline function swaprows!(v::AbstractMatrix{T}, i::Int, j::Int, f1, f2) where T
-    @inbounds for c = 1:size(v, 2)
+Base.@propagate_inbounds function swaprows!(v::AbstractMatrix{T}, i::Int, j::Int, f1, f2) where T
+    for c = 1:size(v, 2)
         temp = v[i, c]
         v[i, c] = v[j, c]*f2
         v[j, c] = temp*f1
@@ -37,8 +37,8 @@ function swaprows! end
     v
 end
 
-@inline function swaprows!(v::AbstractMatrix{T}, i::Int, j::Int) where T
-    @inbounds for c = 1:size(v, 2)
+Base.@propagate_inbounds function swaprows!(v::AbstractMatrix{T}, i::Int, j::Int) where T
+    for c = 1:size(v, 2)
         temp = v[i, c]
         v[i, c] = v[j, c]
         v[j, c] = temp
@@ -53,8 +53,8 @@ swap col i and col j of v inplace, with f1, f2 factors applied on i and j (befor
 """
 function swapcols! end
 
-@inline function swapcols!(v::AbstractMatrix{T}, i::Int, j::Int, f1, f2) where T
-    @inbounds for c = 1:size(v, 1)
+Base.@propagate_inbounds function swapcols!(v::AbstractMatrix{T}, i::Int, j::Int, f1, f2) where T
+    for c = 1:size(v, 1)
         temp = v[c, i]
         v[c, i] = v[c, j]*f2
         v[c, j] = temp*f1
@@ -62,8 +62,8 @@ function swapcols! end
     v
 end
 
-@inline function swapcols!(v::AbstractMatrix{T}, i::Int, j::Int) where T
-    @inbounds for c = 1:size(v, 1)
+Base.@propagate_inbounds function swapcols!(v::AbstractMatrix{T}, i::Int, j::Int) where T
+    for c = 1:size(v, 1)
         temp = v[c, i]
         v[c, i] = v[c, j]
         v[c, j] = temp
@@ -71,16 +71,16 @@ end
     v
 end
 
-@inline swapcols!(v::AbstractVector, args...) = swaprows!(v, args...)
+Base.@propagate_inbounds swapcols!(v::AbstractVector, args...) = swaprows!(v, args...)
 
-@inline @inbounds function swaprows!(v::AbstractVector, i::Int, j::Int, f1, f2)
+Base.@propagate_inbounds function swaprows!(v::AbstractVector, i::Int, j::Int, f1, f2)
     temp = v[i]
     v[i] = v[j]*f2
     v[j] = temp*f1
     v
 end
 
-@inline @inbounds function swaprows!(v::AbstractVector, i::Int, j::Int)
+Base.@propagate_inbounds function swaprows!(v::AbstractVector, i::Int, j::Int)
     temp = v[i]
     v[i] = v[j]
     v[j] = temp
@@ -94,7 +94,7 @@ apply u1 on row i and row j of state inplace.
 """
 function u1rows! end
 
-@inline @inbounds function u1rows!(state::AbstractVector, i::Int, j::Int, a, b, c, d)
+Base.@propagate_inbounds function u1rows!(state::AbstractVector, i::Int, j::Int, a, b, c, d)
     w = state[i]
     v = state[j]
     state[i] = a*w+b*v
@@ -102,8 +102,8 @@ function u1rows! end
     state
 end
 
-@inline function u1rows!(state::AbstractMatrix, i::Int,j::Int, a, b, c, d)
-    @inbounds for col = 1:size(state, 2)
+Base.@propagate_inbounds function u1rows!(state::AbstractMatrix, i::Int,j::Int, a, b, c, d)
+    for col = 1:size(state, 2)
         w = state[i, col]
         v = state[j, col]
         state[i, col] = a*w+b*v
@@ -119,12 +119,16 @@ multiply row i of v by f inplace.
 """
 function mulrow! end
 
-@inline mulrow!(v::AbstractVector, i::Int, f) = (v[i] *= f; v)
-@inline function mulrow!(v::AbstractMatrix, i::Int, f)
-    @inbounds for j = 1:size(v, 2)
+Base.@propagate_inbounds function mulrow!(v::AbstractVector, i::Int, f)
+    v[i] *= f
+    return v
+end
+
+Base.@propagate_inbounds function mulrow!(v::AbstractMatrix, i::Int, f)
+    for j = 1:size(v, 2)
         v[i, j] *= f
     end
-    v
+    return v
 end
 
 """
@@ -134,13 +138,16 @@ multiply col i of v by f inplace.
 """
 function mulcol! end
 
+Base.@propagate_inbounds function mulcol!(v::AbstractVector, i::Int, f)
+    v[i] *= f
+    return v
+end
 
-@inline mulcol!(v::AbstractVector, i::Int, f) = (v[i] *= f; v)
-@inline function mulcol!(v::AbstractMatrix, j::Int, f)
-    @inbounds for i = 1:size(v, 1)
+Base.@propagate_inbounds function mulcol!(v::AbstractMatrix, j::Int, f)
+    for i = 1:size(v, 1)
         v[i, j] *= f
     end
-    v
+    return v
 end
 
 """
@@ -153,52 +160,52 @@ function matvec end
 matvec(x::AbstractMatrix) = size(x, 2) == 1 ? vec(x) : x
 matvec(x::AbstractVector) = x
 
-@inline function unrows!(state::AbstractVector, inds::AbstractVector, U::AbstractMatrix)
-    @inbounds state[inds] = U*state[inds]
-    state
+Base.@propagate_inbounds function unrows!(state::AbstractVector, inds::AbstractVector, U::AbstractMatrix)
+    state[inds] = U*state[inds]
+    return state
 end
 
-@inline function unrows!(state::AbstractMatrix, inds::AbstractVector, U::AbstractMatrix)
-    @inbounds for k in 1:size(state, 2)
+Base.@propagate_inbounds function unrows!(state::AbstractMatrix, inds::AbstractVector, U::AbstractMatrix)
+    for k in 1:size(state, 2)
         state[inds, k] = U*state[inds, k]
     end
-    state
+    return state
 end
 
 ############# boost unrows! for sparse matrices ################
 @inline unrows!(state::AbstractVector, inds::AbstractVector, U::IMatrix) = state
 
-@inline function unrows!(state::AbstractVector, inds::AbstractVector, U::SDDiagonal)
+Base.@propagate_inbounds function unrows!(state::AbstractVector, inds::AbstractVector, U::SDDiagonal)
     for i in 1:length(U.diag)
-        @inbounds state[inds[i]] *= U.diag[i]
+        state[inds[i]] *= U.diag[i]
     end
-    state
+    return state
 end
 
-@inline function unrows!(state::AbstractMatrix, inds::AbstractVector, U::SDDiagonal)
+Base.@propagate_inbounds function unrows!(state::AbstractMatrix, inds::AbstractVector, U::SDDiagonal)
     for j in 1:size(state, 2)
         for i in 1:length(U.diag)
-            @inbounds state[inds[i],j] *= U.diag[i]
+            state[inds[i],j] *= U.diag[i]
         end
     end
     state
 end
 
-@inline function unrows!(state::AbstractVector, inds::AbstractVector, U::SDPermMatrix)
-    @inbounds state[inds] = state[inds[U.perm]] .* U.vals
+Base.@propagate_inbounds function unrows!(state::AbstractVector, inds::AbstractVector, U::SDPermMatrix)
+    state[inds] = state[inds[U.perm]] .* U.vals
     state
 end
 
-@inline function unrows!(state::AbstractMatrix, inds::AbstractVector, U::SDPermMatrix)
-    @inbounds for k in 1:size(state, 2)
+Base.@propagate_inbounds function unrows!(state::AbstractMatrix, inds::AbstractVector, U::SDPermMatrix)
+    for k in 1:size(state, 2)
         state[inds, k] = state[inds[U.perm], k] .* U.vals
     end
     state
 end
 
-@inline function unrows!(state::AbstractVector, inds::AbstractVector, A::SDSparseMatrixCSC, work::AbstractVector)
+Base.@propagate_inbounds function unrows!(state::AbstractVector, inds::AbstractVector, A::SDSparseMatrixCSC, work::AbstractVector)
     work .= 0
-    @inbounds for col = 1:length(inds)
+    for col = 1:length(inds)
         xj = state[inds[col]]
         for j = A.colptr[col]:(A.colptr[col + 1] - 1)
             work[A.rowval[j]] += A.nzval[j]*xj
@@ -208,9 +215,9 @@ end
     state
 end
 
-@inline function unrows!(state::AbstractMatrix, inds::AbstractVector, A::SDSparseMatrixCSC, work::Matrix)
+Base.@propagate_inbounds function unrows!(state::AbstractMatrix, inds::AbstractVector, A::SDSparseMatrixCSC, work::Matrix)
     work .= 0
-    @inbounds for k = 1:size(state, 2)
+    for k = 1:size(state, 2)
         for col = 1:length(inds)
             xj = state[inds[col],k]
             for j = A.colptr[col]:(A.colptr[col + 1] - 1)


### PR DESCRIPTION
not a big problem, since julia know how to hoist the boundscheck sometimes now, but some of the instruct didn't correctly inbounds the callee

before:

```jl
julia> @benchmark instruct!(st, Val(:T), (3, )) setup=(st=rand(ComplexF64, 1<<15))
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     17.568 μs (0.00% GC)
  median time:      19.893 μs (0.00% GC)
  mean time:        20.972 μs (0.00% GC)
  maximum time:     130.544 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```

after

```jl
julia> @benchmark instruct!(st, Val(:T), (3, )) setup=(st=rand(ComplexF64, 1<<15))
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     14.798 μs (0.00% GC)
  median time:      17.689 μs (0.00% GC)
  mean time:        18.589 μs (0.00% GC)
  maximum time:     109.593 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```