### PR TITLE
rm matvec & furthur optimize performance

### DIFF
--- a/src/instruct.jl
+++ b/src/instruct.jl
@@ -9,9 +9,20 @@
 using YaoBase, BitBasis, LuxurySparse, StaticArrays
 export instruct!
 
-function YaoBase.instruct!(reg::ArrayReg, operator, args...; kwargs...)
-    instruct!(matvec(reg.state), operator, args...; kwargs...)
-    return reg
+function YaoBase.instruct!(r::ArrayReg, op, locs::Tuple, control_locs::Tuple, control_bits::Tuple)
+    instruct!(r.state, op, locs, control_locs, control_bits)
+end
+
+function YaoBase.instruct!(r::ArrayReg, op, locs::Tuple)
+    instruct!(r.state, op, locs)
+end
+
+function YaoBase.instruct!(r::ArrayReg, op, locs::Tuple, control_locs::Tuple, control_bits::Tuple, theta::Number)
+    instruct!(r.state, op, locs, control_locs, control_bits, theta)
+end
+
+function YaoBase.instruct!(r::ArrayReg, op, locs::Tuple, theta::Number)
+    instruct!(r.state, op, locs, theta)
 end
 
 """
@@ -326,18 +337,52 @@ for G in [:Rx, :Ry, :Rz, :CPHASE]
         instruct!(state, m, locs, control_locs, control_bits)
         return state
     end
-
-    @eval function YaoBase.instruct!(
-            state::AbstractVecOrMat{T},
-            g::Val{$(QuoteNode(G))},
-            locs::NTuple{N, Int},
-            theta::Number
-        ) where {T, N}
-        m = rot_mat(T, g, theta)
-        instruct!(state, m, locs)
-        return state
-    end
 end # for
+
+@inline function YaoBase.instruct!(
+        state::AbstractVecOrMat{T},
+        ::Val{:Rx},
+        (loc, )::Tuple{Int},
+        theta::Number
+    ) where {T, N}
+    a, b = cos(theta / 2), -im*sin(theta / 2)
+    instruct_kernel(state, loc, 1 << (loc - 1), 1 << loc, a, b, b, a)
+    return state
+end
+
+function YaoBase.instruct!(
+        state::AbstractVecOrMat{T},
+        ::Val{:Ry},
+        (loc, )::Tuple{Int},
+        theta::Number
+    ) where {T, N}
+    a, b = cos(theta / 2), sin(theta / 2)
+    instruct_kernel(state, loc, 1 << (loc - 1), 1 << loc, a, -b, b, a)
+    return state
+end
+
+function YaoBase.instruct!(
+        state::AbstractVecOrMat{T},
+        ::Val{:Rz},
+        (loc, )::Tuple{Int},
+        theta::Number
+    ) where {T, N}
+    a, d = exp(-im * theta / 2), exp(im * theta / 2)
+    instruct_kernel(state, loc, 1 << (loc - 1), 1 << loc, a, zero(T), zero(T), d)
+    return state
+end
+
+function YaoBase.instruct!(
+    state::AbstractVecOrMat{T},
+    ::Val{:CPHASE},
+    locs::NTuple{N, Int},
+    theta::Number
+) where {T, N}
+    m = rot_mat(T, Val(:CPHASE), theta)
+    instruct!(state, m, locs)
+    return state
+end
+
 
 # forward single gates
 function YaoBase.instruct!(

--- a/test/instruct.jl
+++ b/test/instruct.jl
@@ -146,3 +146,11 @@ end
         @test instruct!(copy(st), Val(G), ()) == st
     end
 end
+
+@testset "register insterface" begin
+      r = rand_state(5)
+      @test instruct!(copy(r), Val(:X), (2, )) ≈ instruct!(copy(r.state), Val(:X), (2, ))
+      @test instruct!(copy(r), Val(:X), (2, ), (3, ), (1, )) ≈ instruct!(copy(r.state), Val(:X), (2, ), (3, ), (1, ))
+      @test instruct!(copy(r), Val(:Rx), (2, ), 0.5) ≈ instruct!(copy(r.state), Val(:Rx), (2, ), 0.5)
+      @test instruct!(copy(r), Val(:Rx), (2, ), (3, ), (1, ), 0.5) ≈ instruct!(copy(r.state), Val(:Rx), (2, ), (3, ), (1, ), 0.5)
+end


### PR DESCRIPTION
this further optimizes the performance of rotation gates.

```jl
@benchmark apply!(r, $(put(5, 2=>Rx(0.5)))) setup=(r=rand_state(5))
```

before:

```julia
BenchmarkTools.Trial: 
  memory estimate:  688 bytes
  allocs estimate:  17
  --------------
  minimum time:     424.719 ns (0.00% GC)
  median time:      441.246 ns (0.00% GC)
  mean time:        473.802 ns (5.99% GC)
  maximum time:     10.010 μs (95.16% GC)
  --------------
  samples:          10000
  evals/sample:     199
```

after:

```julia
BenchmarkTools.Trial: 
  memory estimate:  32 bytes
  allocs estimate:  2
  --------------
  minimum time:     72.515 ns (0.00% GC)
  median time:      92.314 ns (0.00% GC)
  mean time:        94.292 ns (0.72% GC)
  maximum time:     1.508 μs (93.35% GC)
  --------------
  samples:          10000
  evals/sample:     954
```