### PR TITLE
support adapt interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "e600142f-9330-5003-8abb-0ebd767abc51"
 version = "0.7.7"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 BitBasis = "50ba71b6-fa0f-514d-ae9a-0916efc90dcf"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LuxurySparse = "d05aeea4-b7d4-55ac-b691-9e7fabb07ba2"
@@ -13,6 +14,7 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 YaoBase = "a8f54c17-34bc-5a9d-b050-f522fe3f755f"
 
 [compat]
+Adapt = "3"
 BitBasis = "0.7"
 LuxurySparse = "0.6"
 StaticArrays = "0.12, 1.0"

--- a/src/YaoArrayRegister.jl
+++ b/src/YaoArrayRegister.jl
@@ -6,7 +6,9 @@ able to simulate a quantum circuit alone with this package in principle.
 """
 module YaoArrayRegister
 
-using YaoBase, BitBasis
+using Adapt
+using YaoBase
+using BitBasis
 
 export ArrayReg,
     AdjointArrayReg,

--- a/src/register.jl
+++ b/src/register.jl
@@ -11,6 +11,8 @@ mutable struct ArrayReg{B,T,MT<:AbstractMatrix{T}} <: AbstractRegister{B}
     state::MT
 end
 
+Adapt.@adapt_structure ArrayReg
+
 const AdjointArrayReg{B,T,MT} = AdjointRegister{B,ArrayReg{B,T,MT}}
 const ArrayRegOrAdjointArrayReg{B,T,MT} =
     Union{ArrayReg{B,T,MT},AdjointRegister{B,ArrayReg{B,T,MT}}}

--- a/test/register.jl
+++ b/test/register.jl
@@ -1,5 +1,6 @@
 using Test, YaoArrayRegister, BitBasis, LinearAlgebra
 using YaoBase
+using Adapt
 
 @testset "test constructors" begin
     @test ArrayReg{3}(rand(4, 6)) isa ArrayReg{3}
@@ -193,4 +194,8 @@ end
     reg1 = focus!(copy(rega), (3, 2, 4))
     reg2 = focus!(copy(regb), (3, 2, 4))
     @test reg1' * reg2 ≈ rega' * regb
+end
+
+@testset "adapt" begin
+    @test datatype(adapt(Array{ComplexF32}, zero_state(5))) == ComplexF32
 end


### PR DESCRIPTION
make `Adapt.adapt` work on `ArrayReg` now a few things should just work on `ArrayReg` such as `CUDA.cu`, `CUDA.Adaptor` etc.