### PR TITLE
implement norm

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -2,7 +2,7 @@
 
 using LinearAlgebra
 
-export isnormalized, normalize!, regadd!, regsub!, regscale!
+export isnormalized, normalize!, regadd!, regsub!, regscale!, norm
 
 """
     isnormalized(r::ArrayReg) -> Bool
@@ -24,6 +24,9 @@ function LinearAlgebra.normalize!(r::ArrayReg{B}) where {B}
 end
 
 LinearAlgebra.normalize!(r::AdjointArrayReg) = (normalize!(parent(r)); r)
+
+LinearAlgebra.norm(r::ArrayReg{1}) = norm(statevec(r))
+LinearAlgebra.norm(r::ArrayReg{B}) where B = [norm(view(reshape(r.state, :, B), :, ib)) for ib=1:B]
 
 # basic arithmatics
 

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -35,12 +35,15 @@ end
     @test all(state(reg * 2 - reg / 0.5) .== 0)
 
     reg = rand_state(3)
+    @test norm(reg) ≈ 1
     @test reg' * reg ≈ 1
 
     @test state(reg1 * 2) == state(reg1) * 2
     @test state(reg1' * 2) == state(reg1') * 2
     @test reg1 * 2 == 2 * reg1
     @test reg1' * 2 == 2 * reg1'
+    reg = rand_state(3; nbatch=2) * 2
+    @test norm(reg) ≈ [2.0, 2.0]
 end
 
 @testset "partial ⟨bra|ket⟩" begin


### PR DESCRIPTION
Current `norm(reg)` will call into the fallback in Base and freeze julia. Meanwhile, since we have `normalize!` function, it is intuitive to have a `norm` function.